### PR TITLE
Fix build error by externalizing color-thief-browser

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "@redwoodjs/forms": "8.8.0",
     "@redwoodjs/router": "8.8.0",
     "@redwoodjs/web": "8.8.0",
+    "color-thief-browser": "^2.0.2",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,6 +11,11 @@ dns.setDefaultResultOrder('verbatim')
 
 const viteConfig: UserConfig = {
   plugins: [redwood()],
+  build: {
+    rollupOptions: {
+      external: ['color-thief-browser'],
+    },
+  },
 }
 
 export default defineConfig(viteConfig)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11262,6 +11262,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-thief-browser@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "color-thief-browser@npm:2.0.2"
+  checksum: 10c0/1800ef4086ac5a925fdf737f3be6288090893d4c0d3535164e41b405880f60f6df4b0c8b169cec84d8df234d88462d19c0b24e8636ca0802bf03690cb4207ab4
+  languageName: node
+  linkType: hard
+
 "color@npm:^3.1.3":
   version: 3.2.1
   resolution: "color@npm:3.2.1"
@@ -24250,6 +24257,7 @@ __metadata:
     "@redwoodjs/web": "npm:8.8.0"
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
+    color-thief-browser: "npm:^2.0.2"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
   languageName: unknown


### PR DESCRIPTION
## Summary
- add `color-thief-browser` dependency in the web workspace
- update Vite config to externalize `color-thief-browser`

## Testing
- `CI=true yarn rw test --watchAll=false` *(fails: execa.sync is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688792d91efc8323bcb380a1afd5e2dc